### PR TITLE
feat: Create Spring Boot client for mcp-context

### DIFF
--- a/mcp-context-client/pom.xml
+++ b/mcp-context-client/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.1.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>mcp-context-client</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>mcp-context-client</name>
+	<description>Demo project for Spring Boot</description>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>4.9.3</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/McpContextClientApplication.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/McpContextClientApplication.java
@@ -1,0 +1,15 @@
+package com.example.mcpcontextclient;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = "com.example.mcpcontextclient.service")
+public class McpContextClientApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(McpContextClientApplication.class, args);
+	}
+
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/AppendMessagesRequest.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/AppendMessagesRequest.java
@@ -1,0 +1,15 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppendMessagesRequest {
+    private String contextId;
+    private List<Message> messages;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/Context.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/Context.java
@@ -1,0 +1,13 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class Context {
+    private String id;
+    private String name;
+    private String description;
+    private List<Message> messages;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/ContextWindow.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/ContextWindow.java
@@ -1,0 +1,11 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ContextWindow {
+    private List<Message> messages;
+    private int tokenCount;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/CreateContextRequest.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/CreateContextRequest.java
@@ -1,0 +1,17 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateContextRequest {
+    private String namespaceId;
+    private String name;
+    private String description;
+    private List<Message> initialMessages;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/GetContextWindowRequest.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/GetContextWindowRequest.java
@@ -1,0 +1,14 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetContextWindowRequest {
+    private String contextId;
+    private int maxTokens;
+    private String strategy;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/Message.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/Message.java
@@ -1,0 +1,13 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Message {
+    private String role;
+    private String content;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/SearchContextsRequest.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/SearchContextsRequest.java
@@ -1,0 +1,15 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchContextsRequest {
+    private String query;
+    private String namespaceId;
+    private int limit;
+    private boolean includeShared;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/ShareContextRequest.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/model/ShareContextRequest.java
@@ -1,0 +1,15 @@
+package com.example.mcpcontextclient.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShareContextRequest {
+    private String contextId;
+    private String targetOrgId;
+    private String accessLevel;
+    private Integer expiresInHours;
+}

--- a/mcp-context-client/src/main/java/com/example/mcpcontextclient/service/McpContextService.java
+++ b/mcp-context-client/src/main/java/com/example/mcpcontextclient/service/McpContextService.java
@@ -1,0 +1,58 @@
+package com.example.mcpcontextclient.service;
+
+import com.example.mcpcontextclient.model.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class McpContextService {
+
+    private final WebClient webClient;
+
+    public McpContextService(WebClient.Builder webClientBuilder, @Value("${mcp.context.client.baseUrl}") String baseUrl) {
+        this.webClient = webClientBuilder.baseUrl(baseUrl).build();
+    }
+
+    public Mono<Context> createContext(CreateContextRequest request) {
+        return webClient.post()
+                .uri("/contexts")
+                .body(Mono.just(request), CreateContextRequest.class)
+                .retrieve()
+                .bodyToMono(Context.class);
+    }
+
+    public Mono<Void> appendToContext(AppendMessagesRequest request) {
+        return webClient.post()
+                .uri("/contexts/append")
+                .body(Mono.just(request), AppendMessagesRequest.class)
+                .retrieve()
+                .bodyToMono(Void.class);
+    }
+
+    public Mono<ContextWindow> getContextWindow(GetContextWindowRequest request) {
+        return webClient.post()
+                .uri("/contexts/window")
+                .body(Mono.just(request), GetContextWindowRequest.class)
+                .retrieve()
+                .bodyToMono(ContextWindow.class);
+    }
+
+    public Mono<Void> shareContext(ShareContextRequest request) {
+        return webClient.post()
+                .uri("/contexts/share")
+                .body(Mono.just(request), ShareContextRequest.class)
+                .retrieve()
+                .bodyToMono(Void.class);
+    }
+
+    public Flux<Context> searchContexts(SearchContextsRequest request) {
+        return webClient.post()
+                .uri("/contexts/search")
+                .body(Mono.just(request), SearchContextsRequest.class)
+                .retrieve()
+                .bodyToFlux(Context.class);
+    }
+}

--- a/mcp-context-client/src/main/resources/application.properties
+++ b/mcp-context-client/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+mcp.context.client.baseUrl=http://localhost:8080

--- a/mcp-context-client/src/test/java/com/example/mcpcontextclient/McpContextClientApplicationTests.java
+++ b/mcp-context-client/src/test/java/com/example/mcpcontextclient/McpContextClientApplicationTests.java
@@ -1,0 +1,13 @@
+package com.example.mcpcontextclient;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class McpContextClientApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/mcp-context-client/src/test/java/com/example/mcpcontextclient/service/McpContextServiceTest.java
+++ b/mcp-context-client/src/test/java/com/example/mcpcontextclient/service/McpContextServiceTest.java
@@ -1,0 +1,120 @@
+package com.example.mcpcontextclient.service;
+
+import com.example.mcpcontextclient.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class McpContextServiceTest {
+
+    private static MockWebServer mockWebServer;
+    private McpContextService mcpContextService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @BeforeEach
+    void initialize() {
+        String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
+        mcpContextService = new McpContextService(WebClient.builder(), baseUrl);
+    }
+
+    @Test
+    void testCreateContext() throws JsonProcessingException {
+        Context context = new Context();
+        context.setId("123");
+        context.setName("Test Context");
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(context))
+                .addHeader("Content-Type", "application/json"));
+
+        CreateContextRequest request = new CreateContextRequest("ns1", "Test Context", "Test Description", Collections.emptyList());
+
+        Mono<Context> contextMono = mcpContextService.createContext(request);
+
+        StepVerifier.create(contextMono)
+                .expectNextMatches(c -> c.getId().equals("123"))
+                .verifyComplete();
+    }
+
+    @Test
+    void testAppendToContext() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+
+        AppendMessagesRequest request = new AppendMessagesRequest("123", Collections.singletonList(new Message("user", "Hello")));
+
+        Mono<Void> result = mcpContextService.appendToContext(request);
+
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
+    @Test
+    void testGetContextWindow() throws JsonProcessingException {
+        ContextWindow contextWindow = new ContextWindow();
+        contextWindow.setTokenCount(10);
+        contextWindow.setMessages(Collections.singletonList(new Message("user", "Hello")));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(contextWindow))
+                .addHeader("Content-Type", "application/json"));
+
+        GetContextWindowRequest request = new GetContextWindowRequest("123", 100, "full");
+
+        Mono<ContextWindow> contextWindowMono = mcpContextService.getContextWindow(request);
+
+        StepVerifier.create(contextWindowMono)
+                .expectNextMatches(cw -> cw.getTokenCount() == 10)
+                .verifyComplete();
+    }
+
+    @Test
+    void testShareContext() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+
+        ShareContextRequest request = new ShareContextRequest("123", "org2", "read", 24);
+
+        Mono<Void> result = mcpContextService.shareContext(request);
+
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
+    @Test
+    void testSearchContexts() throws JsonProcessingException {
+        Context context = new Context();
+        context.setId("123");
+        context.setName("Test Context");
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(Collections.singletonList(context)))
+                .addHeader("Content-Type", "application/json"));
+
+        SearchContextsRequest request = new SearchContextsRequest("Test", "ns1", 10, true);
+
+        StepVerifier.create(mcpContextService.searchContexts(request))
+                .expectNextMatches(c -> c.getId().equals("123"))
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
This commit introduces a new Spring Boot client for the `mcp-context` service.

The client is a Maven-based project located in the `mcp-context-client` directory. It includes:
- Models for the `mcp-context` API.
- A `McpContextService` that uses `WebClient` to interact with the `mcp-context` API.
- A comprehensive test suite for the `McpContextService` using `MockWebServer`.

The following steps were taken to create the client:
1. Created a new Spring Boot project.
2. Defined the data models based on the `mcp-context` service's API.
3. Implemented the `McpContextService` to make calls to the `mcp-context` API.
4. Wrote a full suite of tests for the service, using a mock web server to simulate the API responses.
5. Configured the project to use a properties file for the base URL of the service.

The tests are passing, and the client is ready for use.

I was about to start working on the `mcp-debate` client, but I am submitting my current work as you requested.