### PR TITLE
fix: Update Maven configuration to fix CI pipeline failure

### DIFF
--- a/pmd.xml
+++ b/pmd.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Custom PMD Ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        Custom PMD ruleset for the project
+    </description>
+
+    <!-- Best Practices -->
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="JUnitTestsShouldIncludeAssert"/>
+        <exclude name="JUnitAssertionsShouldIncludeMessage"/>
+    </rule>
+
+    <!-- Code Style -->
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="OnlyOneReturn"/>
+        <exclude name="AtLeastOneConstructor"/>
+        <exclude name="LocalVariableCouldBeFinal"/>
+        <exclude name="MethodArgumentCouldBeFinal"/>
+        <exclude name="ShortVariable"/>
+        <exclude name="LongVariable"/>
+        <exclude name="CommentDefaultAccessModifier"/>
+    </rule>
+
+    <!-- Design -->
+    <rule ref="category/java/design.xml">
+        <exclude name="LawOfDemeter"/>
+        <exclude name="LoosePackageCoupling"/>
+        <exclude name="TooManyMethods"/>
+        <exclude name="UseUtilityClass"/>
+    </rule>
+
+    <!-- Error Prone -->
+    <rule ref="category/java/errorprone.xml">
+        <exclude name="BeanMembersShouldSerialize"/>
+        <exclude name="DataflowAnomalyAnalysis"/>
+    </rule>
+
+    <!-- Performance -->
+    <rule ref="category/java/performance.xml"/>
+
+    <!-- Security -->
+    <rule ref="category/java/security.xml"/>
+
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <module>karate-api-tests</module>
         <module>load-tests</module>
         <module>mcp-sidecar</module>
-        <!-- <module>performance-tests/gatling</module> Does not exist -->
+        <module>performance-tests/gatling</module>
         <module>server</module>
         <module>workflow-editor</module>
         <!-- Legacy modules (to be phased out) -->
@@ -402,7 +402,7 @@
                         <effort>Max</effort>
                         <threshold>Low</threshold>
                         <xmlOutput>true</xmlOutput>
-                        <excludeFilterFile>.linting/java/spotbugs-exclude.xml</excludeFilterFile>
+                        <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
                         <includeTests>false</includeTests>
                         <outputDirectory>${project.build.directory}/spotbugs</outputDirectory>
                         <xmlOutputDirectory>${project.build.directory}/spotbugs</xmlOutputDirectory>
@@ -429,8 +429,8 @@
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.5.0</version>
                     <configuration>
-                        <configLocation>.linting/java/checkstyle.xml</configLocation>
-                        <suppressionsLocation>.linting/java/checkstyle-suppressions.xml</suppressionsLocation>
+                        <configLocation>checkstyle.xml</configLocation>
+                        <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
                         <violationSeverity>warning</violationSeverity>
@@ -523,7 +523,7 @@
                     <version>3.25.0</version>
                     <configuration>
                         <rulesets>
-                            <ruleset>.linting/java/pmd.xml</ruleset>
+                            <ruleset>pmd.xml</ruleset>
                         </rulesets>
                         <printFailingErrors>true</printFailingErrors>
                         <failOnViolation>true</failOnViolation>


### PR DESCRIPTION
- Fixed configuration file paths for checkstyle, spotbugs, and PMD plugins
- Created missing pmd.xml configuration file with standard Java rules
- Re-enabled performance-tests/gatling module (module exists with valid tests)
- Updated spotbugs exclude filter path from .linting/java/ to root directory
- Updated checkstyle config and suppressions paths to root directory

This resolves the Java Build & Test job failure in the CI pipeline by ensuring all referenced configuration files exist at the correct paths.